### PR TITLE
Add MackDing community skill repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 收录最全、更新最快的AI Agent技能库，涵盖**文档处理、内容创作、编程开发、机器学习、自动化工作流**等多个领域的精选技能包。
 
-[![官方技能](https://img.shields.io/badge/官方技能-182-blue?style=flat-square)](https://github.com/anbeime/skill)
+[![官方技能](https://img.shields.io/badge/官方技能-185-blue?style=flat-square)](https://github.com/anbeime/skill)
 [![本地技能](https://img.shields.io/badge/本地技能-61-green?style=flat-square)](https://github.com/anbeime/skill)
 [![备份覆盖](https://img.shields.io/badge/备份覆盖-100%25-success?style=flat-square)](https://github.com/anbeime/skill)
 [![自动更新](https://img.shields.io/badge/更新-每24小时-orange?style=flat-square)](https://github.com/anbeime/skill)
 
 ## 📊 统计数据
 
-- **官方技能**: 182 个（来自 awesome-agent-skills，自动爬取）
+- **官方技能**: 185 个（来自 awesome-agent-skills 和社区提交）
 - **本地技能**: 61 个（25核心 + 30子技能 + 6系统内置）
-- **技能总数**: 243 个（官方 + 本地）
+- **技能总数**: 246 个（官方 + 本地）
 - **备份覆盖率**: 100%（71个压缩包，完整备份）
 - **自动更新**: 每24小时自动爬取最新技能
 
@@ -45,6 +45,7 @@
 - **Expo** (3个) - expo-app-design, expo-deployment, upgrading-expo
 - **Sentry** (7个) - code-review, commit, create-pr, find-bugs 等
 - **Better Auth** (3个) - best-practices, commands, create-auth
+- **Community Submissions** (3个) - AI-native founder playbook, coding agent guidelines, skill usage monitoring
 - **其他团队** - Tinybird, Remotion, Inngest 等
 
 ## 💾 本地技能库（61个）

--- a/data/skills.json
+++ b/data/skills.json
@@ -1455,8 +1455,32 @@
       "category": "Other",
       "source": "VoltAgent/awesome-agent-skills",
       "crawled_at": "2026-02-02T17:07:33.816746"
+    },
+    {
+      "name": "MackDing/ai-native-founder-playbook-skill",
+      "description": "Bilingual, vendor-neutral Agent Skill for startup idea validation, customer discovery, MVP scoping, PMF diagnostics, launch operations, GTM planning, and AI-native founder workflows.",
+      "link": "https://github.com/MackDing/ai-native-founder-playbook-skill",
+      "category": "Business and Marketing",
+      "source": "Community submission",
+      "crawled_at": "2026-05-26T00:00:00.000000"
+    },
+    {
+      "name": "MackDing/andrej-karpathy-skills-zh",
+      "description": "Chinese Claude Code, Codex, Cursor, and AI coding agent rules that turn Karpathy-inspired coding principles into reusable CLAUDE.md, AGENTS.md, Cursor Rules, and Skill formats.",
+      "link": "https://github.com/MackDing/andrej-karpathy-skills-zh",
+      "category": "Development and Testing",
+      "source": "Community submission",
+      "crawled_at": "2026-05-26T00:00:00.000000"
+    },
+    {
+      "name": "MackDing/skill-usage",
+      "description": "Zero-dependency real-time dashboard for monitoring OpenClaw, Hermes-Agent, Claude Code, and Codex skill calls, latency, failures, and redundant or idle skills.",
+      "link": "https://github.com/MackDing/skill-usage",
+      "category": "Productivity and Collaboration",
+      "source": "Community submission",
+      "crawled_at": "2026-05-26T00:00:00.000000"
     }
   ],
-  "total": 182,
-  "updated_at": "2026-02-02T17:07:33.819738"
+  "total": 185,
+  "updated_at": "2026-05-26T00:00:00.000000"
 }

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -1455,8 +1455,32 @@
       "category": "Other",
       "source": "VoltAgent/awesome-agent-skills",
       "crawled_at": "2026-02-02T17:07:33.816746"
+    },
+    {
+      "name": "MackDing/ai-native-founder-playbook-skill",
+      "description": "Bilingual, vendor-neutral Agent Skill for startup idea validation, customer discovery, MVP scoping, PMF diagnostics, launch operations, GTM planning, and AI-native founder workflows.",
+      "link": "https://github.com/MackDing/ai-native-founder-playbook-skill",
+      "category": "Business and Marketing",
+      "source": "Community submission",
+      "crawled_at": "2026-05-26T00:00:00.000000"
+    },
+    {
+      "name": "MackDing/andrej-karpathy-skills-zh",
+      "description": "Chinese Claude Code, Codex, Cursor, and AI coding agent rules that turn Karpathy-inspired coding principles into reusable CLAUDE.md, AGENTS.md, Cursor Rules, and Skill formats.",
+      "link": "https://github.com/MackDing/andrej-karpathy-skills-zh",
+      "category": "Development and Testing",
+      "source": "Community submission",
+      "crawled_at": "2026-05-26T00:00:00.000000"
+    },
+    {
+      "name": "MackDing/skill-usage",
+      "description": "Zero-dependency real-time dashboard for monitoring OpenClaw, Hermes-Agent, Claude Code, and Codex skill calls, latency, failures, and redundant or idle skills.",
+      "link": "https://github.com/MackDing/skill-usage",
+      "category": "Productivity and Collaboration",
+      "source": "Community submission",
+      "crawled_at": "2026-05-26T00:00:00.000000"
     }
   ],
-  "total": 182,
-  "updated_at": "2026-02-02T17:07:33.819738"
+  "total": 185,
+  "updated_at": "2026-05-26T00:00:00.000000"
 }


### PR DESCRIPTION
## Summary
- Add three MackDing community skill repositories to data/skills.json and public/data/skills.json
- Update README skill counts and source summary
- Include AI-Native Founder Playbook, Andrej Karpathy Coding Guidelines ZH, and Skill Usage

## Notes
The added repositories cover startup/founder workflows, Chinese AI coding-agent rules, and skill usage monitoring for OpenClaw, Hermes-Agent, Claude Code, and Codex.