### PR TITLE
fix: 用基于项目根目录的相对路径替代硬编码绝对路径

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,6 +3,11 @@
 技能商店自动更新配置文件
 """
 
+from pathlib import Path
+
+# 项目根目录（基于本文件位置自动解析，保证在任何机器上可运行）
+BASE_DIR = Path(__file__).resolve().parent
+
 # GitHub 仓库配置
 GITHUB_REPO_URL = "https://github.com/VoltAgent/awesome-agent-skills"
 GITHUB_RAW_README_URL = "https://raw.githubusercontent.com/VoltAgent/awesome-agent-skills/main/README.md"
@@ -10,14 +15,14 @@ GITHUB_RAW_README_URL = "https://raw.githubusercontent.com/VoltAgent/awesome-age
 # 更新频率配置（秒）
 UPDATE_INTERVAL = 3600 * 24  # 每24小时更新一次
 
-# 数据存储路径
-DATA_DIR = "C:\\D\\StepFun\\skill_store_updater\\data"
-SKILLS_JSON_PATH = f"{DATA_DIR}\\skills.json"
-LAST_UPDATE_PATH = f"{DATA_DIR}\\last_update.txt"
+# 数据存储路径（相对项目根目录）
+DATA_DIR = str(BASE_DIR / "data")
+SKILLS_JSON_PATH = str(BASE_DIR / "data" / "skills.json")
+LAST_UPDATE_PATH = str(BASE_DIR / "data" / "last_update.txt")
 
 # 日志配置
-LOG_DIR = "C:\\D\\StepFun\\skill_store_updater\\logs"
-LOG_FILE = f"{LOG_DIR}\\updater.log"
+LOG_DIR = str(BASE_DIR / "logs")
+LOG_FILE = str(BASE_DIR / "logs" / "updater.log")
 
 # 技能商店 API 配置（根据实际情况修改）
 SKILL_STORE_API_URL = "http://localhost:8000/api/skills"


### PR DESCRIPTION
## 修复内容

修复 `config.py` 中硬编码的作者本机绝对路径，改为基于项目根目录的相对路径，保证项目在任何环境克隆后可直接运行。

## 修改前

```python
DATA_DIR = r"C:\D\StepFun\skill_store_updater\data"
LOG_DIR = r"C:\D\StepFun\skill_store_updater\logs"
```

换机器运行必然报错（FileNotFoundError）。

## 修改后

```python
BASE_DIR = Path(__file__).resolve().parent
DATA_DIR = BASE_DIR / "data"
LOG_DIR = BASE_DIR / "logs"
```

基于 `__file__` 自动解析项目根目录，任何环境克隆后可直接运行，也方便后续打包部署。

## 验证

- [x] `python main.py --stats` 正常运行，成功加载 182 个技能
- [x] 数据文件读写路径均指向项目目录
