### PR TITLE
feat: add ledger-tasks-yylo skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@
 - **multi-agent-meeting** ⭐⭐ - 多智能体会议
 - **peers-advisory-group** ⭐⭐ - 同行顾问团
 
-### 💼 产品与项目管理（2个）
+### 💼 产品与项目管理（3个）
 - **product-manager-toolkit** ⭐⭐⭐ - 产品经理工具包
 - **sales-ai-assistant** ⭐⭐ - 销售AI助手
+- **ledger-tasks-yylo** ⭐⭐⭐⭐ - 基于 YYLO Ledger 的 git 原生看板/任务账本：依赖排序、状态回执、多 worktree 串行交付，驱动 AI 编程代理的多步骤任务
 
 ### 🎨 设计与可视化（4个）
 - **frontend-design** ⭐⭐⭐ - 前端界面设计

--- a/skills/ledger-tasks-yylo/README.md
+++ b/skills/ledger-tasks-yylo/README.md
@@ -1,0 +1,41 @@
+# YYLO Ledger Tasks (ledger-tasks-yylo)
+
+让 AI 编程代理通过 git 原生的看板/任务账本驱动多步骤开发：任务状态、依赖排序、状态回执与多 worktree 串行交付，全部以文件形式保存在仓库内，跨会话可审计。
+
+## 适用场景
+
+- 多步骤、跨会话的功能开发与任务追踪
+- 依赖感知的并行执行排序（拓扑排序、阻塞关系）
+- 状态流转必须留痕（`--response` 回执 + `--commit` 关联）
+- 多 agent / 多 worktree 协作的串行合并交付
+
+## 核心原则
+
+1. 先读后写：`yy ledger list` / `get` / `ready` 了解现状再变更。
+2. 任务粒度小：一次迭代可完成，避免撑爆上下文。
+3. 每次状态变更必须带 `--response` 回执，说明做了什么、如何验证。
+4. 依赖显式建模：`deps add` 声明阻塞关系，环会被自动检测。
+5. 绝不直接编辑 `.juno_task/` 文件，CLI 是唯一合法入口。
+
+## 安装
+
+```bash
+npm install -g @yylo/cli
+```
+
+要求 Node >= 20。
+
+## 常用命令
+
+```bash
+yy ledger create "任务描述" --status todo --tags feature
+yy ledger ready                 # 查看无阻塞任务
+yy ledger order --scores        # 拓扑排序，规划并行执行
+yy ledger mark in_progress --id TASK_ID --response "开始实现"
+yy ledger mark done --id TASK_ID --response "完成并测试" --commit abc123
+```
+
+## 技能来源
+
+来源：<https://github.com/yylo-dev/yylo-skills>（MIT）。
+依赖外部 YYLO CLI：<https://github.com/yylo-dev/yylo>。

--- a/skills/ledger-tasks-yylo/SKILL.md
+++ b/skills/ledger-tasks-yylo/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: ledger-tasks-yylo
+description: Drive multi-step coding-agent work through a git-native Kanban/task ledger. Use when an agent needs persistent task state across sessions, dependency-aware ordering, status transitions with receipts, or serialized multi-worktree delivery. For task/board operations, not memory or general notes.
+---
+
+# YYLO Ledger Tasks
+
+Use this skill when a coding agent needs persistent, reviewable task state that lives in the repository and drives multi-step feature work across sessions.
+
+## When to Use
+
+- Planning or executing a multi-step feature that spans several sessions or agents
+- Tracking a task board (backlog → todo → in_progress → done) as files inside the repo
+- Ordering work by dependencies before starting parallel agents
+- Recording status changes with an explicit response receipt and commit link
+- Coordinating feature worktrees with serialized merge delivery
+
+## Required Workflow
+
+1. Read state before mutating: `yy ledger list`, `yy ledger get TASK_ID`, `yy ledger ready`.
+2. Create small, one-iteration tasks: `yy ledger create "Implement X" --status todo --tags backend`.
+3. Record every transition with a receipt: `yy ledger mark in_progress --id TASK_ID --response "Starting: scope Y"`.
+4. Model blockers explicitly: `yy ledger deps add --id TASK_ID --blocked-by BLOCKER1 BLOCKER2`.
+5. Plan parallel work topologically: `yy ledger order --scores`.
+6. Link outcomes to git: mark done with `--response` plus `--commit HASH`.
+7. Never edit `.juno_task/` files directly; the CLI is the only sanctioned mutation path and fails closed on controller errors.
+
+## Core Commands
+
+```bash
+yy ledger create "Task description" --status todo --tags feature,backend
+yy ledger list --status todo,in_progress --limit 10
+yy ledger search --tag backend --open
+yy ledger get TASK_ID
+yy ledger mark in_progress --id TASK_ID --response "Starting work"
+yy ledger mark done --id TASK_ID --response "Done: implemented X, tested Y" --commit abc123
+yy ledger update TASK_ID --tags backend,urgent
+yy ledger deps TASK_ID
+yy ledger ready
+yy ledger order --scores
+```
+
+## Answer Shape
+
+When answering task questions, include:
+
+- the task's current status and unresolved blockers
+- the receipt (`--response`) that produced the last transition
+- the next unblocked task from `ready` / `order` when asked what to work on next
+
+## Fallback Rules
+
+- If the `yy` CLI is missing, install it first: `npm install -g @yylo/cli` (Node >= 20).
+- On controller/routing errors, stop and report; never bypass by editing task files.
+- Task state is hot by default; archived tasks surface only via `get` and bounded `archive-search`.
+- Cross-project routing is opt-in via registry config; without it, operate from the project root only.
+
+## Source
+
+Canonical home: https://github.com/yylo-dev/yylo-skills (MIT). Requires the external YYLO CLI: https://github.com/yylo-dev/yylo

--- a/skills/ledger-tasks-yylo/metadata.json
+++ b/skills/ledger-tasks-yylo/metadata.json
@@ -1,0 +1,30 @@
+{
+  "name": "ledger-tasks-yylo",
+  "version": "1.0.0",
+  "description": "Git-native Kanban/task ledger that drives coding agents through task lifecycles with dependency ordering, status receipts, and serialized merge delivery.",
+  "author": "yylo-dev",
+  "source": "https://github.com/yylo-dev/yylo-skills",
+  "license": "MIT",
+  "dependencies": {
+    "node": ">=20",
+    "npm": "@yylo/cli"
+  },
+  "platforms": ["macOS", "Linux", "Windows"],
+  "tags": [
+    "yylo",
+    "kanban",
+    "task-management",
+    "coding-agent",
+    "dependencies",
+    "workflow",
+    "ledger"
+  ],
+  "triggers": [
+    "yy ledger",
+    "kanban",
+    "task board",
+    "task dependencies",
+    "mark in_progress",
+    "what task next"
+  ]
+}


### PR DESCRIPTION
## 概要 / Summary

- 新增技能 `ledger-tasks-yylo`：基于 YYLO Ledger 的 git 原生看板/任务账本，驱动 AI 编程代理完成多步骤任务——依赖排序、状态回执（`--response`）、多 worktree 串行交付，任务状态以文件形式保存在仓库内、跨会话可审计
- 包含 `SKILL.md`、技能级 `README.md` 与 `metadata.json`，并在主 README 的「💼 产品与项目管理」分类追加一行索引（2个 → 3个）
- 目录形态与本仓库最近一次外部技能导入 `ontoly-software-graph`（PR #9，2026-09-02 落地）一致：单层目录 + metadata.json + README 索引行

## 验证 / Validation

- 本地运行仓库自带验证器：`python tools/skill_validator.py validate skills/ledger-tasks-yylo` → **0 errors, 0 warnings**
- `python3 -m json.tool skills/ledger-tasks-yylo/metadata.json` → OK
- 主 README 仅 +1 行索引、分类计数 2→3，未改动其他内容（diff 共 4 个文件，全部为新增）

## 来源与声明 / Source & Disclosure

- 技能来源（canonical home）：https://github.com/yylo-dev/yylo-skills （MIT）
- 依赖外部 CLI：`npm install -g @yylo/cli`（https://github.com/yylo-dev/yylo ，MIT，活跃开发中）
- 提交者为 YYLO 团队成员；PR 由 AI agent 协助准备，内容已按仓库规范自检。分类/星级/文案如需调整，欢迎直接修改——也欢迎以直接提交的方式落地（仓库惯例我们已了解）
